### PR TITLE
Fixed error when file changed

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -164,7 +164,7 @@ export default {
      * @returns {void}
      */
     setFiles(e) {
-      this.files = getFileListOnEvent(e);
+      this.files = Array.from(getFileListOnEvent(e));
 
       this.exception = '';
     },
@@ -240,7 +240,7 @@ export default {
      * コンバートから1件消す
      */
     deleteConverted(index) {
-      this.converted.splice(index, 1);
+      this.converted.splice(index, 1)[0]?.unload();
     },
 
     setPreviewConverted(index) {
@@ -258,6 +258,10 @@ export default {
      */
     resetConverted() {
       if (this.flags.convert) return;
+
+      for (const convert of this.converted) {
+        convert.unload()
+      }
 
       this.files     = [];
       this.converted = [];

--- a/src/controllers/PictureScale.js
+++ b/src/controllers/PictureScale.js
@@ -30,7 +30,8 @@ export default {
       };
     }
 
-    const scaled = await this._scale(file, orgSize, scalePer, pixelSize);
+    const [orgImageData, url] = await fileToImageData(file, orgSize.width, orgSize.height, 1 / pixelSize);
+    const scaled = await this._scale(orgImageData, orgSize, scalePer, pixelSize);
 
     return {
       status: 'success',
@@ -41,6 +42,7 @@ export default {
         pixelSize: pixelSize
       },
       org: file,
+      unload: () => URL.revokeObjectURL(url),
     };
   },
 
@@ -65,14 +67,13 @@ export default {
 
   /**
    * xBRを実行するやつ
-   * @param {File} file
+   * @param {ImageData} orgSizeImageData
    * @param {{width: number, height: number}} orgSize
    * @param {number} scalePer (100-400)
    * @param {number} pixelSize (1-4)
    * @returns {Promise<ImageData>}
    */
-  async _scale(file, orgSize, scalePer, pixelSize) {
-    const orgSizeImageData = await fileToImageData(file, orgSize.width, orgSize.height, 1 / pixelSize);
+  async _scale(orgSizeImageData, orgSize, scalePer, pixelSize) {
     let array = new Uint32Array(orgSizeImageData.data.buffer);
 
     // for big pixel image

--- a/src/lib/FileUtil.js
+++ b/src/lib/FileUtil.js
@@ -1,4 +1,3 @@
-import FileReaderSync from './FileReaderSync';
 import FileSaver from 'file-saver';
 
 /**
@@ -25,10 +24,10 @@ export const toShowable = (blob) => {
  * @param {number} width
  * @param {number} height
  * @param {number} scale (0-1)
- * @returns {Promise<ImageData>}
+ * @returns {Promise<[ImageData, string]>}
  */
 export const fileToImageData = async (file, width, height, scale = 1) => {
-  const blob = await (new FileReaderSync()).readAsDataURL(file);
+  const blob = URL.createObjectURL(file)
 
   const canvas  = document.createElement('canvas');
   canvas.width  = width * scale;
@@ -45,7 +44,7 @@ export const fileToImageData = async (file, width, height, scale = 1) => {
       const scaledHeight = parseInt(img.naturalHeight * scale);
 
       ctx.drawImage(img, 0, 0, img.naturalWidth, img.naturalHeight, 0, 0, scaledWidth, scaledHeight);
-      resolve(ctx.getImageData(0, 0, scaledWidth, scaledHeight));
+      resolve([ctx.getImageData(0, 0, scaledWidth, scaledHeight), blob]);
     };
 
     img.onerror = (err) => {


### PR DESCRIPTION
Hello! I saw this site on twitter and thought it was really cool! I noticed that there were some topics mentioned in the issues page so I figure I'd contribute a bit.

Example development site: https://poohcom1.github.io/pixel-scaler/

### #4 Error thrown when original file has changed and convert is clicked
 - Replaced `FileReaderSync` with `URL.createObjectUrl` in `fileToImageData()`
   - Added `unload` method to convert result to revoke url
   - Called unload on image deletion and convert resets

The main issue is that `FileReader` throws "DOMException: File could not be read" when the original file has been change. Not sure why this happens, but it could be related to file locking when the file is being edited. It turns out that using `URL.createObjectUrl` does not have this issue. 

This seems to fix the problem when I tested it, but I'm not sure if there's a reason FileReaderSync is preferred over createObjectUrl. Can you confirm this?

### [BUG] Loaded file count not updating when new file clicked
 - Made `this.files` an array to propagate change

A minor bug I noticed, where the selected file length doesn't update when new files are selected. This is probably due to Vue not observing the FileList data type, so changing it to an array fixes the issue.