### PR TITLE
Fix error when file change with File System API

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -265,9 +265,9 @@ export default {
         convert.unload()
       }
 
-      this.fileHandles     = [];
-      this.converted = [];
-      this.errors    = [];
+      this.fileHandles = [];
+      this.converted   = [];
+      this.errors      = [];
     },
 
     /**

--- a/src/App.vue
+++ b/src/App.vue
@@ -22,10 +22,9 @@
 
         <div class="row margin-tb-2">
           <div class="col margin-tb-1">
-            <label class="box circle hover active pointer flex-grow-1 margin-tb-1" @dragover.prevent @drop.prevent="setFiles">
-              <input type="file" accept="image/png, image/jpeg, image/gif" multiple @change="setFiles">
-              <v-fa :icon="['far', 'file-image']"/> {{files.length ? $t('select', {count: files.length}) : $t('no-select')}}
-            </label>
+            <file-input @filechange="setFiles">
+              <v-fa :icon="['far', 'file-image']"/> {{fileHandles.length ? $t('select', {count: fileHandles.length}) : $t('no-select')}}
+            </file-input>
           </div>
 
           <div class="col margin-tb-1">
@@ -101,7 +100,7 @@
     </footer>
 
     <transition name="fade">
-      <preview-conteiner v-if="flags.showPreviewConverted"
+      <preview-container v-if="flags.showPreviewConverted"
                          :image="previewConverted"
                          @close="flags.showPreviewConverted = false"/>
     </transition>
@@ -112,7 +111,7 @@
 
 <script>
 import {scaledImagesToZip} from './lib/Archive';
-import {getFileListOnEvent, download} from './lib/FileUtil';
+import {download} from './lib/FileUtil';
 import {isWeb, isElectron} from './lib/System';
 import {checkVersion} from './lib/Version';
 
@@ -130,7 +129,8 @@ import ColorContainer     from './components/ColorContainer.vue';
 import LinkContainer      from './components/LinkContainer.vue';
 import VersionContainer   from './components/VersionContainer.vue';
 import ExceptionContainer from './components/ExceptionContainer.vue';
-import PreviewConteiner   from './components/PreviewContainer.vue';
+import PreviewContainer   from './components/PreviewContainer.vue';
+import FileInput          from './components/FileInput.vue';
 
 export default {
   name: 'app',
@@ -141,7 +141,7 @@ export default {
         org: 1,
       },
       scale: 200,
-      files: [],
+      fileHandles: [],
       converted: [],
       errors: [],
       exception: null,
@@ -160,11 +160,11 @@ export default {
   methods: {
     /**
      * ファイル配列を変数に入れるやつ
-     * @param {Event} e
+     * @param {FileSystemFileHandle[]} fileHandles An array of FileHandles
      * @returns {void}
      */
-    setFiles(e) {
-      this.files = Array.from(getFileListOnEvent(e));
+    setFiles(fileHandles) {
+      this.fileHandles = fileHandles;
 
       this.exception = '';
     },
@@ -178,13 +178,15 @@ export default {
 
       [this.pixel, this.scale] = PictureScale.adjustParams(this.pixel, this.scale);
 
-      if (this.flags.convert || this.files.length === 0) {
+      if (this.flags.convert || this.fileHandles.length === 0) {
         return;
       }
 
       this.flags.convert = true;
 
-      for (const file of this.files) {
+      for (const fileHandle of this.fileHandles) {
+        const file = await fileHandle.getFile()
+
         await PictureScale.scale(file, this.scale, this.pixelSize.org).then(result => {
           if (result.status === 'success') {
             this.converted.push(result);
@@ -263,7 +265,7 @@ export default {
         convert.unload()
       }
 
-      this.files     = [];
+      this.fileHandles     = [];
       this.converted = [];
       this.errors    = [];
     },
@@ -339,7 +341,8 @@ export default {
     LinkContainer,
     VersionContainer,
     ExceptionContainer,
-    PreviewConteiner,
+    PreviewContainer, 
+    FileInput,
   },
 }
 </script>

--- a/src/components/FileInput.vue
+++ b/src/components/FileInput.vue
@@ -1,0 +1,91 @@
+<template>
+  <label class="box circle hover active pointer flex-grow-1 margin-tb-1" @dragover.prevent @drop.prevent="onDrop">
+    <input type="file" accept="image/png, image/jpeg, image/gif" multiple @click="onClick" @change="onChange">
+    <!-- @slot Use this for the label text -->
+    <slot></slot>
+  </label>
+</template>
+<script>
+import { NativeFileHandle } from '../lib/FileUtil';
+
+const acceptedTypes = [
+  "image/png",
+  "image/gif",
+  "image/jpeg"
+]
+
+const pickerOpts = {
+  types: [
+    {
+      description: 'Images',
+      accept: {
+        'image/*': ['.png', '.gif', '.jpeg', '.jpg']
+      }
+    },
+  ],
+  excludeAcceptAllOption: true,
+  multiple: true
+};
+
+/**
+ * A input wrapper for file upload that uses the File System API.
+ *  Will fallbacks to native event upload if the File System API is not supported on the browser.
+ * 
+ * @emits filechange Fires when files are uploaded. File handles are sent as the argument
+ */
+export default {
+  data() {
+    return {
+      hasFileSystemAccess: !!window.showOpenFilePicker,
+      files: [],
+    }
+  },
+  methods: {
+    // For browsers with File System Access API (chrome, edge)
+    async onClick(e) {
+      if (this.hasFileSystemAccess) {
+        e.preventDefault()
+        const fileHandles = await window.showOpenFilePicker(pickerOpts)
+
+        this.$emit("filechange", fileHandles)
+      }
+    },
+    async onDrop(e) {
+      if (this.hasFileSystemAccess) {
+        e.preventDefault()
+        let fileHandles = []
+
+        const items = [...e.dataTransfer.items]
+
+        // FIXME: This only works for the first file
+        for (const item of items) {
+          if (item.kind === "file") {
+            if (acceptedTypes.includes(item.type)) {
+              const entry = await item.getAsFileSystemHandle();
+
+              fileHandles.push(entry)
+            } else {
+              console.warn("Unsupported file type dropped")
+            }
+          }
+        }
+
+        this.$emit("filechange", fileHandles)
+      } else {
+        this.onChange(e)
+      }
+    },
+    // For browsers without the File System Access API (Firefox, webkit)
+    onChange(e) {
+      if (!this.hasFileSystemAccess) {
+        const files = Array.from(e.target.files || e.dataTransfer.files)
+        const handles = files.map(f => new NativeFileHandle(f))
+
+        this.$emit("filechange", handles)
+      }
+    },
+
+  },
+  emits: ["filechange"]
+};
+</script>

--- a/src/controllers/PictureScale.js
+++ b/src/controllers/PictureScale.js
@@ -10,6 +10,8 @@ export default {
    * @return {Promise<{status: string, org: File, image: {base64: string, filename: string, scale: number, pixelSize: number}, message?: string}>}
    */
   async scale(file, scalePer, pixelSize) {
+    const url = URL.createObjectURL(file)
+
     const error = this._validateFile(file);
     if (error !== '') {
       return {
@@ -19,7 +21,16 @@ export default {
       };
     }
 
-    const orgSize = await getFileSize(file);
+    const urlError = await this._validateImageUrl(url)
+    if (urlError !== '') {
+      return {
+        status: 'failed',
+        message: urlError,
+        org: file,
+      };
+    }
+
+    const orgSize = await getFileSize(url);
 
     const sizeError = this._validateFileSize(orgSize, pixelSize);
     if (sizeError !== '') {
@@ -30,7 +41,7 @@ export default {
       };
     }
 
-    const [orgImageData, url] = await fileToImageData(file, orgSize.width, orgSize.height, 1 / pixelSize);
+    const orgImageData = await fileToImageData(url, orgSize.width, orgSize.height, 1 / pixelSize);
     const scaled = await this._scale(orgImageData, orgSize, scalePer, pixelSize);
 
     return {
@@ -135,6 +146,20 @@ export default {
     }
 
     return '';
+  },
+
+  /**
+   * Blob URLのバリデーション
+   * @param {string} url 
+   */
+  async _validateImageUrl(url) {
+    try {
+      await fetch(url)
+
+      return ''
+    } catch (e) {
+      return 'error-invalid-url'
+    }
   },
 
   /**

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -13,6 +13,7 @@
   "error-invalid-file": "Please select a file. ({filename})",
   "error-invalid-image-type": "Please choose png, jpeg or gif. ({filename})",
   "error-invalid-image-size": "The pixel size does not match the picture size. ({filename})",
+  "error-invalid-url": "Unable to load file ({filename}). If the file has been edited, please reupload it.",
 
   "attention": "Attention",
   "attention-01": "There is a bug that the conversion does not work with Safari 14 on iPhone. Please try using a PC.",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -13,7 +13,8 @@
   "error-invalid-file": "ファイルを選択してください ({filename})",
   "error-invalid-image-type": "pngかjpegかgifを選択してください ({filename})",
   "error-invalid-image-size": "ピクセルのサイズとピクチャのサイズが一致しません ({filename})",
-
+  "error-invalid-url": "ファイルを読み込むことができません ({filename})。ファイルを変更した場合は、再度ファイルを選択してください。",
+  
   "attention": "注意",
   "attention-01": "iPhoneのsafari14では変換ができない不具合が発生しています。ご利用の方はPC等でお試しください。",
 

--- a/src/lib/FileUtil.js
+++ b/src/lib/FileUtil.js
@@ -126,3 +126,19 @@ export const getFileSize = async (file) => {
  export const download = (file, name) => {
   FileSaver.saveAs(file, name);
 };
+
+/**
+ * @implements {FileSystemFileHandle}
+ */
+export class NativeFileHandle {
+  /**
+   * @param {Blob} file 
+   */
+  constructor(file) {
+    this._file = file
+  }
+
+  async getFile() {
+    return this._file
+  }
+}

--- a/src/lib/FileUtil.js
+++ b/src/lib/FileUtil.js
@@ -128,6 +128,7 @@ export const getFileSize = async (file) => {
 };
 
 /**
+ * FileHandle wrapper for regular files
  * @implements {FileSystemFileHandle}
  */
 export class NativeFileHandle {
@@ -140,5 +141,30 @@ export class NativeFileHandle {
 
   async getFile() {
     return this._file
+  }
+}
+
+/**
+ * FileHandle wrapper for FileSystemFileEntry
+ * @implements {FileSystemFileHandle}
+ */
+export class EntryFileHandle {
+  /**
+   * 
+   * @param {FileSystemFileEntry} entry 
+   */
+  constructor(entry) {
+    this._entry = entry
+  }
+
+  async getFile() {
+    return new Promise((resolve, reject) => {
+      this._entry.file((file) => {
+        resolve(file)
+      },
+      () => {
+        reject()
+      })
+    })
   }
 }

--- a/src/lib/FileUtil.js
+++ b/src/lib/FileUtil.js
@@ -20,15 +20,13 @@ export const toShowable = (blob) => {
 
 /**
  * FileをImageDataに変換するやつ
- * @param {File}   file
+ * @param {string} url
  * @param {number} width
  * @param {number} height
  * @param {number} scale (0-1)
- * @returns {Promise<[ImageData, string]>}
+ * @returns {Promise<ImageData>}
  */
-export const fileToImageData = async (file, width, height, scale = 1) => {
-  const blob = URL.createObjectURL(file)
-
+export const fileToImageData = async (url, width, height, scale = 1) => {
   const canvas  = document.createElement('canvas');
   canvas.width  = width * scale;
   canvas.height = height * scale;
@@ -37,14 +35,14 @@ export const fileToImageData = async (file, width, height, scale = 1) => {
 
   return new Promise((resolve, reject) => {
     const img = new Image();
-    img.src   = blob;
+    img.src = url;
 
     img.onload = () => {
       const scaledWidth  = parseInt(img.naturalWidth * scale);
       const scaledHeight = parseInt(img.naturalHeight * scale);
 
       ctx.drawImage(img, 0, 0, img.naturalWidth, img.naturalHeight, 0, 0, scaledWidth, scaledHeight);
-      resolve([ctx.getImageData(0, 0, scaledWidth, scaledHeight), blob]);
+      resolve(ctx.getImageData(0, 0, scaledWidth, scaledHeight));
     };
 
     img.onerror = (err) => {
@@ -92,10 +90,10 @@ export const fileToImageData = async (file, width, height, scale = 1) => {
 
 /**
  * Fileから縦横のサイズを返すやつ
- * @param {File} file
+ * @param {string} url
  * @returns {Promise<{width: number, height: number}>}
  */
-export const getFileSize = async (file) => {
+export const getFileSize = async (url) => {
   return new Promise((resolve, reject) => {
     const img = new Image();
 
@@ -105,7 +103,6 @@ export const getFileSize = async (file) => {
         height: img.naturalHeight,
       };
 
-      URL.revokeObjectURL(img.src);
       resolve(size);
     };
 
@@ -113,7 +110,7 @@ export const getFileSize = async (file) => {
       reject(err);
     };
 
-    img.src = URL.createObjectURL(file);
+    img.src = url;
   });
 };
 

--- a/src/lib/FileUtil.js
+++ b/src/lib/FileUtil.js
@@ -147,7 +147,6 @@ export class NativeFileHandle {
  */
 export class EntryFileHandle {
   /**
-   * 
    * @param {FileSystemFileEntry} entry 
    */
   constructor(entry) {


### PR DESCRIPTION
# Fixes #4: Error when uploaded file is edited

Example site: https://poohcom1.github.io/pixel-scaler/

Tested in:
- Firefox
- Chrome
- Edge

## Changes

- Added `FileInput.vue` component 
  - Wrapper for an input element
  - Uses the [File System Access API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API) for compatible browsers to avoid file changed restrictions
  - Uses `DataTransferItem.webkitGetAsEntry()` for Drag n Drop due to bug with `DataTransferItem.getAsFileSystemHandle()`
  - Changed `this.files` to `this.fileHandles` to allow for different types of file APIs. Wrapper classes are in `FileUtil.js`
 - Improved error handling for image conversion
   - Share a single url from `URL.createObjectUrl` during conversion process instead of having multiple ones
   - Added image url validation to detect errors before loading image, such as file changed errors
   - Added "error-invalid-url" string in EN and JP (I know some Japanese, but I don't know Spanish at all so we'll need someone to add that)

This is a rough implementation since I don't have much experience with Vue. I had to make some decisions like changing `this.files` to `this.fileHandles` and using classes for different data types, so you might prefer other conventions like duck-typing or separate modules for browsers. If so, do please let me know if you want any changes in terms of coding style, I'm more than happy to change the implementation!