### PR TITLE
resolve duplicate vue complier-core types

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,9 @@ import { version } from "./package.json";
 import { pwaConfig } from "./vite/config/pwa";
 import generateLicensePlugin from "./vite/plugins/license";
 
-import type { RootNode, TemplateChildNode } from "@vue/compiler-core";
+import type { CompilerOptions } from "vue/compiler-sfc";
+
+type NodeTransform = NonNullable<CompilerOptions["nodeTransforms"]>[number];
 
 /**
  * Removes `data-testid` attributes from a given node's properties.
@@ -19,7 +21,7 @@ import type { RootNode, TemplateChildNode } from "@vue/compiler-core";
  * @param node - The node to process, which can be either a `RootNode` or a `TemplateChildNode`.
  *               If the node's type is not 1, the function will return without making changes.
  */
-const removeDataTestAttrs = (node: RootNode | TemplateChildNode) => {
+const removeDataTestAttrs: NodeTransform = (node) => {
   if (node.type !== 1) return;
 
   node.props = node.props.filter((prop) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,29 +7,8 @@ import { VitePWA } from "vite-plugin-pwa";
 
 import { version } from "./package.json";
 import { pwaConfig } from "./vite/config/pwa";
+import { removeDataTestAttrs } from "./vite/config/removeDataTestAttrs";
 import generateLicensePlugin from "./vite/plugins/license";
-
-import type { CompilerOptions } from "vue/compiler-sfc";
-
-type NodeTransform = NonNullable<CompilerOptions["nodeTransforms"]>[number];
-
-/**
- * Removes `data-testid` attributes from a given node's properties.
- * This function filters out both static (`data-testid`) and dynamic (`:data-testid`) attributes
- * from the `props` array of the provided node, if applicable.
- *
- * @param node - The node to process, which can be either a `RootNode` or a `TemplateChildNode`.
- *               If the node's type is not 1, the function will return without making changes.
- */
-const removeDataTestAttrs: NodeTransform = (node) => {
-  if (node.type !== 1) return;
-
-  node.props = node.props.filter((prop) => {
-    if (prop.type === 6) return prop.name !== "data-testid";
-    if (prop.type === 7) return prop.rawName !== ":data-testid";
-    return true;
-  });
-};
 
 // https://vitejs.dev/config/
 export default defineConfig((configEnv) => ({

--- a/vite/config/removeDataTestAttrs.ts
+++ b/vite/config/removeDataTestAttrs.ts
@@ -1,0 +1,21 @@
+import type { CompilerOptions } from "vue/compiler-sfc";
+
+type NodeTransform = NonNullable<CompilerOptions["nodeTransforms"]>[number];
+
+/**
+ * Removes `data-testid` attributes from a given node's properties.
+ * This function filters out both static (`data-testid`) and dynamic (`:data-testid`) attributes
+ * from the `props` array of the provided node, if applicable.
+ *
+ * @param node - The node to process. This is a Vue compiler template node transform.
+ *               If the node's type is not 1, the function will return without making changes.
+ */
+export const removeDataTestAttrs: NodeTransform = (node) => {
+  if (node.type !== 1) return;
+
+  node.props = node.props.filter((prop) => {
+    if (prop.type === 6) return prop.name !== "data-testid";
+    if (prop.type === 7) return prop.rawName !== ":data-testid";
+    return true;
+  });
+};


### PR DESCRIPTION
SSIA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Production builds now strip test-related data attributes from Vue templates; these attributes remain in development builds.
  * Build configuration updated to use a dedicated transform for removing those attributes; no user-facing API changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irokaru/pixel-scaler/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->